### PR TITLE
Add upload functionality - initial

### DIFF
--- a/ARte/pwa/forms.py
+++ b/ARte/pwa/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class UploadFileForm(forms.Form):
+    file = forms.ImageField(required=False)

--- a/ARte/pwa/helpers.py
+++ b/ARte/pwa/helpers.py
@@ -1,0 +1,8 @@
+from django.contrib.staticfiles.templatetags.staticfiles import static
+
+
+def handle_upload_image(image):
+    path = "pwa" + static(f"images/{image.name}")
+    with open(path, 'wb+') as destination:
+        for chunk in image.chunks():
+            destination.write(chunk)

--- a/ARte/pwa/jinja2/pwa/upload.jinja2
+++ b/ARte/pwa/jinja2/pwa/upload.jinja2
@@ -1,0 +1,11 @@
+{% extends '/pwa/base.jinja2' %}
+
+{% block content %}
+
+    <form action="{{url('upload-image')}}" method="post" enctype="multipart/form-data">
+        {{ csrf_input }}
+        {{ form }}
+        <input type="submit" value="Upload" />
+    </form>
+
+{% endblock %}

--- a/ARte/pwa/urls.py
+++ b/ARte/pwa/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import service_worker, index
+from .views import service_worker, index, upload_image
 
 
 urlpatterns = [
     path('sw.js', service_worker, name='sw'),
+    path('upload', upload_image, name='upload-image'),
     path('', index, name='index'),
 ]

--- a/ARte/pwa/views.py
+++ b/ARte/pwa/views.py
@@ -1,5 +1,11 @@
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.urls import reverse
+
+from .helpers import handle_upload_image
+from .forms import UploadFileForm
 from .models import Artwork
+
 
 def service_worker(request):
     return render(request, 'pwa/sw.js',
@@ -36,3 +42,15 @@ def index(request):
                 ]
             }
     return render(request, 'pwa/exhibit.jinja2', ctx)
+
+
+def upload_image(request):
+    if request.method == 'POST':
+        form = UploadFileForm(request.POST, request.FILES)
+        image = request.FILES.get('file')
+        if form.is_valid() and image:
+            handle_upload_image(image)
+            return HttpResponseRedirect(reverse('index'))
+    else:
+        form = UploadFileForm()
+    return render(request, 'pwa/upload.jinja2', {'form': form})


### PR DESCRIPTION
Fix #77 

@pablodiegoss This is how I initially implemented the image upload:

1. simple path `/upload` with a form containing only a file input field (no frontend work done here)
2. Once submitted, file is save at `pwa/static/images` and file name is same as user's file name	
3. if image is successful uploaded - return to index page
4. if not, stay at the upload form